### PR TITLE
Update RouteVoiceController.swift

### DIFF
--- a/MapboxNavigation/RouteVoiceController.swift
+++ b/MapboxNavigation/RouteVoiceController.swift
@@ -136,11 +136,11 @@ open class RouteVoiceController: NSObject, AVSpeechSynthesizerDelegate {
     }
     
     @objc func pauseSpeechAndPlayReroutingDing(notification: NSNotification) {
-        speechSynth.stopSpeaking(at: .word)
-        
         guard playRerouteSound && !NavigationSettings.shared.voiceMuted else {
             return
         }
+        
+        speechSynth.stopSpeaking(at: .word)
         
         do {
             try mixAudio()


### PR DESCRIPTION
In pauseSpeechAndPlayReroutingDing method, you stop speechSynth at first and then check if playRerouteSound is true or not. It will stop the voice player after rerouting. I changed the order of the first lines of this method to solve this problem.